### PR TITLE
Updated 'react-hook-form' to be a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20605,10 +20605,9 @@
       }
     },
     "react-hook-form": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.4.2.tgz",
-      "integrity": "sha512-0okvGDiIboTxgWdLTgqsuNeuJPE9YLNuwS0z+1iNvGCYXcHFsrnryI0RCtcFMClflmFKuA4OtD9xZxSrmdLkbw==",
-      "dev": true
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.7.1.tgz",
+      "integrity": "sha512-j5Qw5UJ7jAzpYNnEiK0gDR3jRhcA42hmG5qQVRtXn0Ez5pjwiY5DhE7pzIABS1ZrjkjbM3UPV135319sSepoOA=="
     },
     "react-hot-loader": {
       "version": "4.12.20",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
         "react": "^16.13.1",
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^16.13.1",
-        "react-hook-form": "^5.4.2",
         "react-hot-loader": "^4.12.20",
         "react-router-dom": "^5.1.2",
         "react-test-renderer": "^16.13.1",
@@ -116,6 +115,7 @@
         "@popperjs/core": "^2.3.2",
         "clsx": "^1.1.0",
         "lodash": "^4.17.15",
+        "react-hook-form": "^5.7.1",
         "yup": "^0.28.3"
     },
     "config": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Apparently the `react-hook-form` package was a dev dependency when it should have been a standard dependency

## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.