### PR TITLE
Minor fixes to the TextField and Select components

### DIFF
--- a/src/components/Input/components/Select/index.tsx
+++ b/src/components/Input/components/Select/index.tsx
@@ -17,6 +17,7 @@ import { Props, Option } from './types';
 export const Select = React.forwardRef(({
     options,
     className,
+    isDisabled,
     ...otherProps
 }: Props, ref: React.Ref<any>): React.ReactElement => {
 
@@ -67,6 +68,7 @@ export const Select = React.forwardRef(({
         <MuiSelect
             classes={classes}
             className={classNames}
+            disabled={isDisabled}
             IconComponent={ExpandMoreOutlined}
             MenuProps={MenuProps}
             onClose={(): void => setIsOpen(false)}

--- a/src/components/Input/components/TextField/index.tsx
+++ b/src/components/Input/components/TextField/index.tsx
@@ -63,7 +63,7 @@ export const TextField = React.forwardRef(({
                 {isVisible ? <Visibility /> : <VisibilityOff />}
             </span>
         );
-        return (
+        return hasError && (
             <Grow in={hasError}>
                 <span className="brew-TextField__errorIcon">
                     <ErrorOutline />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request consists of 2 commits:

- TextField: Currently, error icon's container is always present, occupying fixed amount of space at the end of the input. This is especially visible in case of type='number', where up and down arrows are always moved to the left. This commit fixes the issue by displaying error icon's container only if hasError property is set to true.
- Select: Use isDisabled property to disable the component, as other components do.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.