### PR TITLE
Add Dialog component and related theme overrides.

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { Dialog as MuiDialog, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
+
+import { Props } from './types';
+
+import styles from './styles';
+
+import {
+    CheckCircleOutlined,
+    InfoOutlined,
+    WarningOutlined,
+    ErrorOutlined,
+} from '@material-ui/icons';
+
+const defaultIconMapping = {
+    success: <CheckCircleOutlined fontSize="inherit" />,
+    warning: <WarningOutlined fontSize="inherit" />,
+    error: <ErrorOutlined fontSize="inherit" />,
+    info: <InfoOutlined fontSize="inherit" />,
+};
+
+
+/**
+ * Dialogs inform users about a task and can contain critical information, require decisions,
+ * or involve multiple tasks.
+ *
+ * [Material-UI Docs](https://material-ui.com/components/dialogs/)
+ *
+ *
+ * ## Differences in Brewkit:
+ *
+ * - Adds a dialog `title` prop.
+ * - Adds a `severity` prop that determines the icon and the color of the dialog.
+ * - Adds `icon` and `iconMapping` props that allow to change the default icons.
+ */
+export const Dialog = React.forwardRef(({
+    severity = 'success',
+    title,
+    icon,
+    iconMapping = defaultIconMapping,
+    classes,
+    PaperProps,
+    children,
+    ...other
+}: Props, ref: React.Ref<any>): React.ReactElement => {
+    const paperProps = { ...{ elevation: 0 }, ...PaperProps };
+
+    const dialogIcon = icon || iconMapping[severity] || defaultIconMapping[severity];
+    const colorClass = classes[severity];
+
+    return (
+        <MuiDialog
+            PaperProps={paperProps}
+            ref={ref}
+            {...other}
+        >
+            <div className={clsx(classes.icon, colorClass)}>
+                {dialogIcon}
+            </div>
+            <div className={classes.title}>
+                <Typography className={colorClass} variant="h3">{title}</Typography>
+            </div>
+            {children}
+        </MuiDialog>
+    );
+});
+
+Dialog.displayName = 'Dialog';
+
+export default withStyles(styles)(Dialog);

--- a/src/components/Dialog/stories.tsx
+++ b/src/components/Dialog/stories.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { text, select } from '@storybook/addon-knobs';
+import { DialogContent, DialogContentText, DialogActions } from '@material-ui/core';
+import { Button } from '../Button';
+import ContactSupportOutlinedIcon from '@material-ui/icons/ContactSupportOutlined';
+
+import { Dialog as Component } from './index';
+import styles from './styles';
+
+const Dialog = withStyles(styles)(Component);
+
+export default {
+    component: Component,
+    title: 'Data Display/Dialog',
+};
+
+export const Sandbox = (): React.ReactElement => {
+    const [open, setOpen] = React.useState(false);
+
+    const title = text('title', 'Dialog Title');
+    const severity = select('severity', ['error', 'warning', 'info', 'success'], 'success');
+    const dialogText = text('dialogText', 'Dialog description');
+
+    const handleClose = () => setOpen(false);
+
+    return (
+        <React.Fragment>
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                severity={severity}
+                title={title}
+            >
+                <DialogContent>
+                    <DialogContentText>{dialogText}</DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button fullWidth={true} onClick={handleClose}>Confirm</Button>
+                    <Button fullWidth={true} onClick={handleClose} color='secondary'>Second Action</Button>
+                    <Button fullWidth={true} onClick={handleClose} variant='text'>Cancel</Button>
+                </DialogActions>
+
+            </Dialog>
+
+            <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        </React.Fragment>
+    );
+};
+
+export const DifferentIcon = (): React.ReactElement => {
+    const [open, setOpen] = React.useState(false);
+
+    const title = text('title', 'Contact Support?');
+    const severity = select('severity', ['error', 'warning', 'info', 'success'], 'info');
+    const dialogText = text('dialogText', 'Contact support for more information.');
+
+    const handleClose = () => setOpen(false);
+
+    return (
+        <React.Fragment>
+            <Dialog
+                icon={<ContactSupportOutlinedIcon fontSize='inherit' />}
+                open={open}
+                onClose={handleClose}
+                severity={severity}
+                title={title}
+            >
+                <DialogContent>
+                    <DialogContentText>{dialogText}</DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button fullWidth={true} onClick={handleClose}>Confirm</Button>
+                    <Button fullWidth={true} onClick={handleClose} variant='text'>Cancel</Button>
+                </DialogActions>
+
+            </Dialog>
+
+            <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        </React.Fragment>
+    );
+};

--- a/src/components/Dialog/styles.ts
+++ b/src/components/Dialog/styles.ts
@@ -1,0 +1,26 @@
+import { createStyles, Theme } from '@material-ui/core/styles';
+
+const styles = (theme: Theme) => createStyles({
+    icon: {
+        marginBottom: '1rem',
+        fontSize: '3rem',
+        display: 'flex',
+    },
+    success: {
+        color: theme.palette.success.main,
+    },
+    info: {
+        color: theme.palette.info.main,
+    },
+    warning: {
+        color: theme.palette.warning.main,
+    },
+    error: {
+        color: theme.palette.error.main,
+    },
+    title: {
+        marginBottom: '1rem',
+    },
+});
+
+export default styles;

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+import { DialogProps } from '@material-ui/core/Dialog';
+import { WithStyles } from '@material-ui/core/styles';
+
+import styles from './styles';
+
+export type Severity = 'success' | 'info' | 'warning' | 'error';
+
+export type Props = Omit<DialogProps, 'classes' | 'title'> & WithStyles<typeof styles> & {
+
+    /**
+     * The severity of the dialog. This defines the color and icon used.
+     * @default 'success'
+     */
+    severity?: Severity,
+
+    /**
+     * Dialog title
+     */
+    title: NonNullable<React.ReactNode>,
+
+    /**
+     * Overrides the default dialog icon.
+     * Unless provided, the icon is mapped to the value of the `severity` prop.
+     */
+    icon?: React.ReactNode,
+
+    /**
+     * The component maps the `severity` prop to a range of different icons,
+     * for instance success to `<CheckCircleOutlined>`.
+     * If you wish to change this mapping, you can provide your own.
+     * Alternatively, you can use the `icon` prop to override the icon displayed.
+     */
+    iconMapping?: Partial<Record<Severity, React.ReactNode>>,
+};

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -10,3 +10,4 @@ export { default as TextField } from './TextField';
 export { default as Form } from './Form';
 export { default as FormField } from './FormField';
 export { default as FormSubmit } from './FormSubmit';
+export { default as Dialog } from './Dialog';

--- a/themes/cerveza/components/Dialog.d.ts
+++ b/themes/cerveza/components/Dialog.d.ts
@@ -1,0 +1,17 @@
+declare const Dialog: {
+    overrides: {
+        MuiDialog: {
+            paper: {
+                alignItems: string;
+                width: string;
+                padding: string;
+                backgroundColor: string;
+            };
+            container: {
+                backgroundColor: string;
+                opacity: number;
+            };
+        };
+    };
+};
+export default Dialog;

--- a/themes/cerveza/components/Dialog.js
+++ b/themes/cerveza/components/Dialog.js
@@ -1,0 +1,18 @@
+import { color } from '../variables';
+var Dialog = {
+    overrides: {
+        MuiDialog: {
+            paper: {
+                alignItems: 'center',
+                width: '500px',
+                padding: '2rem 1rem',
+                backgroundColor: 'transparent'
+            },
+            container: {
+                backgroundColor: color.blueGray.darkest,
+                opacity: 0.9
+            }
+        }
+    }
+};
+export default Dialog;

--- a/themes/cerveza/components/Dialog.ts
+++ b/themes/cerveza/components/Dialog.ts
@@ -1,0 +1,20 @@
+import { color } from '../variables';
+
+const Dialog = {
+    overrides: {
+        MuiDialog: {
+            paper : {
+                alignItems : 'center',
+                width : '500px',
+                padding : '2rem 1rem',
+                backgroundColor : 'transparent',
+            },
+            container : {
+                backgroundColor : color.blueGray.darkest,
+                opacity : 0.9,
+            },
+        },
+    },
+};
+
+export default Dialog;

--- a/themes/cerveza/components/DialogActions.d.ts
+++ b/themes/cerveza/components/DialogActions.d.ts
@@ -1,0 +1,20 @@
+declare const DialogActions: {
+    overrides: {
+        MuiDialogActions: {
+            root: {
+                display: string;
+                padding: number;
+                width: string;
+            };
+            spacing: {
+                '& > :not(:last-child)': {
+                    marginBottom: string;
+                };
+                '& > :not(:first-child)': {
+                    marginLeft: number;
+                };
+            };
+        };
+    };
+};
+export default DialogActions;

--- a/themes/cerveza/components/DialogActions.js
+++ b/themes/cerveza/components/DialogActions.js
@@ -1,0 +1,20 @@
+var DialogActions = {
+    overrides: {
+        MuiDialogActions: {
+            root: {
+                display: 'block',
+                padding: 0,
+                width: '100%'
+            },
+            spacing: {
+                '& > :not(:last-child)': {
+                    marginBottom: '1rem'
+                },
+                '& > :not(:first-child)': {
+                    marginLeft: 0
+                }
+            }
+        }
+    }
+};
+export default DialogActions;

--- a/themes/cerveza/components/DialogActions.ts
+++ b/themes/cerveza/components/DialogActions.ts
@@ -1,0 +1,21 @@
+const DialogActions = {
+    overrides: {
+        MuiDialogActions : {
+            root: {
+                display: 'block',
+                padding : 0,
+                width : '100%',
+            },
+            spacing: {
+                '& > :not(:last-child)': {
+                    marginBottom: '1rem',
+                },
+                '& > :not(:first-child)': {
+                    marginLeft: 0,
+                },
+            },
+        },
+    },
+};
+
+export default DialogActions;

--- a/themes/cerveza/components/DialogContent.d.ts
+++ b/themes/cerveza/components/DialogContent.d.ts
@@ -1,0 +1,13 @@
+declare const DialogContent: {
+    overrides: {
+        MuiDialogContent: {
+            root: {
+                padding: number;
+                '&:not(:last-child)': {
+                    marginBottom: string;
+                };
+            };
+        };
+    };
+};
+export default DialogContent;

--- a/themes/cerveza/components/DialogContent.js
+++ b/themes/cerveza/components/DialogContent.js
@@ -1,0 +1,13 @@
+var DialogContent = {
+    overrides: {
+        MuiDialogContent: {
+            root: {
+                padding: 0,
+                '&:not(:last-child)': {
+                    marginBottom: '2rem'
+                }
+            }
+        }
+    }
+};
+export default DialogContent;

--- a/themes/cerveza/components/DialogContent.ts
+++ b/themes/cerveza/components/DialogContent.ts
@@ -1,0 +1,14 @@
+const DialogContent = {
+    overrides: {
+        MuiDialogContent : {
+            root: {
+                padding: 0,
+                '&:not(:last-child)': {
+                    marginBottom : '2rem'
+                },
+            },
+        },
+    },
+};
+
+export default DialogContent;

--- a/themes/cerveza/components/DialogContentText.d.ts
+++ b/themes/cerveza/components/DialogContentText.d.ts
@@ -1,0 +1,15 @@
+declare const DialogContentText: {
+    overrides: {
+        MuiDialogContentText: {
+            root: {
+                color: string;
+                textAlign: string;
+                marginBottom: string;
+                '&:last-child': {
+                    marginBottom: number;
+                };
+            };
+        };
+    };
+};
+export default DialogContentText;

--- a/themes/cerveza/components/DialogContentText.js
+++ b/themes/cerveza/components/DialogContentText.js
@@ -1,0 +1,16 @@
+import { color } from '../variables';
+var DialogContentText = {
+    overrides: {
+        MuiDialogContentText: {
+            root: {
+                color: color.blueGray.light,
+                textAlign: "center",
+                marginBottom: '1rem',
+                '&:last-child': {
+                    marginBottom: 0
+                }
+            }
+        }
+    }
+};
+export default DialogContentText;

--- a/themes/cerveza/components/DialogContentText.ts
+++ b/themes/cerveza/components/DialogContentText.ts
@@ -1,0 +1,18 @@
+import { color } from '../variables';
+
+const DialogContentText = {
+    overrides: {
+        MuiDialogContentText : {
+            root: {
+                color: color.blueGray.light,
+                textAlign: "center",
+                marginBottom: '1rem',
+                '&:last-child': {
+                    marginBottom : 0,
+                },
+            },
+        },
+    },
+};
+
+export default DialogContentText;

--- a/themes/cerveza/index.js
+++ b/themes/cerveza/index.js
@@ -17,6 +17,10 @@ import InputLabel from './components/InputLabel';
 import OutlinedInput from './components/OutlinedInput';
 import Select from './components/Select';
 import Switch from './components/Switch';
+import Dialog from './components/Dialog';
+import DialogContent from './components/DialogContent';
+import DialogContentText from './components/DialogContentText';
+import DialogActions from './components/DialogActions';
 var Cerveza = createMuiTheme(_merge({
     palette: {
         primary: {
@@ -45,5 +49,5 @@ var Cerveza = createMuiTheme(_merge({
             primary: color.gray.dark
         }
     }
-}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput));
+}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput, Dialog, DialogContent, DialogContentText, DialogActions));
 export default Cerveza;

--- a/themes/cerveza/index.ts
+++ b/themes/cerveza/index.ts
@@ -19,6 +19,10 @@ import InputLabel from './components/InputLabel';
 import OutlinedInput from './components/OutlinedInput';
 import Select from './components/Select';
 import Switch from './components/Switch';
+import Dialog from './components/Dialog';
+import DialogContent from './components/DialogContent';
+import DialogContentText from './components/DialogContentText';
+import DialogActions from './components/DialogActions';
 
 
 // @ts-ignore
@@ -78,6 +82,10 @@ const Cerveza = createMuiTheme(_merge(
     FormControlLabel,
     InputLabel,
     OutlinedInput,
+    Dialog,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
 ));
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request adds a Dialog to components and theme overrides to Cerveza.
The Dialog component can be used similar to [Material-UI Dialog](https://material-ui.com/components/dialogs/), with the following differences:
- It has a `title` prop, which should be used instead on Material-UI's DialogTitle, since the dialog should typically have a single title.
- `severity` prop defines the icon and color of the dialog, similar to the [Alert](https://material-ui.com/components/alert/) component
- `icon` and `iconMapping` props allow to change default icons, similar to the  [Alert](https://material-ui.com/components/alert/) component

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.