### PR TITLE
Add theme overrides for MuiTabs, MuiTab and MuiTooltip components

### DIFF
--- a/themes/cerveza/components/Tab.d.ts
+++ b/themes/cerveza/components/Tab.d.ts
@@ -1,0 +1,37 @@
+declare const Tab: {
+    overrides: {
+        MuiTab: {
+            root: {
+                padding: string;
+                fontSize: string;
+                lineHeight: number;
+                fontWeight: string;
+                '@media (min-width: 600px)': {
+                    minWidth: number;
+                };
+            };
+            textColorPrimary: {
+                color: string;
+            };
+            textColorSecondary: {
+                color: string;
+            };
+            wrapper: {
+                flexDirection: string;
+            };
+            labelIcon: {
+                minHeight: number;
+                paddingTop: string;
+                '& $wrapper > *:first-child': {
+                    marginBottom: number;
+                    marginRight: string;
+                };
+            };
+            wrapped: {
+                fontSize: string;
+                lineHeight: number;
+            };
+        };
+    };
+};
+export default Tab;

--- a/themes/cerveza/components/Tab.js
+++ b/themes/cerveza/components/Tab.js
@@ -1,0 +1,38 @@
+import { color, size } from '../variables';
+var Tab = {
+    overrides: {
+        MuiTab: {
+            root: {
+                padding: '1rem 1rem 0.875rem 1rem',
+                fontSize: size.small,
+                lineHeight: 1,
+                fontWeight: 'bold',
+                '@media (min-width: 600px)': {
+                    minWidth: 0
+                }
+            },
+            textColorPrimary: {
+                color: color.blueGray.dark
+            },
+            textColorSecondary: {
+                color: color.blueGray.dark
+            },
+            wrapper: {
+                flexDirection: 'row'
+            },
+            labelIcon: {
+                minHeight: 0,
+                paddingTop: size.normal,
+                '& $wrapper > *:first-child': {
+                    marginBottom: 0,
+                    marginRight: size.xsmall
+                }
+            },
+            wrapped: {
+                fontSize: size.small,
+                lineHeight: 1
+            }
+        }
+    }
+};
+export default Tab;

--- a/themes/cerveza/components/Tab.ts
+++ b/themes/cerveza/components/Tab.ts
@@ -1,0 +1,52 @@
+import { color, size } from '../variables';
+
+const Tab = {
+
+    overrides: {
+
+        MuiTab : {
+
+            root : {
+                padding : '1rem 1rem 0.875rem 1rem',
+                fontSize : size.small,
+                lineHeight: 1,
+                fontWeight : 'bold',
+
+                '@media (min-width: 600px)': {
+                    minWidth: 0
+                },
+            },
+
+            textColorPrimary: {
+                color: color.blueGray.dark,
+            },
+
+            textColorSecondary: {
+                color: color.blueGray.dark,
+            },
+
+            wrapper : {
+                flexDirection: 'row',
+            },
+
+            labelIcon : {
+                minHeight: 0,
+                paddingTop: size.normal,
+                '& $wrapper > *:first-child': {
+                    marginBottom : 0,
+                    marginRight: size.xsmall,
+                },
+            },
+
+            wrapped: {
+                fontSize : size.small,
+                lineHeight: 1,
+            },
+
+        },
+
+    }
+
+};
+
+export default Tab;

--- a/themes/cerveza/components/Tabs.d.ts
+++ b/themes/cerveza/components/Tabs.d.ts
@@ -1,0 +1,19 @@
+declare const Tabs: {
+    props: {
+        MuiTabs: {
+            indicatorColor: string;
+            textColor: string;
+        };
+    };
+    overrides: {
+        MuiTabs: {
+            root: {
+                borderBottom: string;
+            };
+            indicator: {
+                height: string;
+            };
+        };
+    };
+};
+export default Tabs;

--- a/themes/cerveza/components/Tabs.js
+++ b/themes/cerveza/components/Tabs.js
@@ -1,0 +1,20 @@
+import { color, size } from '../variables';
+var Tabs = {
+    props: {
+        MuiTabs: {
+            indicatorColor: 'primary',
+            textColor: 'primary'
+        }
+    },
+    overrides: {
+        MuiTabs: {
+            root: {
+                borderBottom: '2px solid ' + color.brand.tertiary
+            },
+            indicator: {
+                height: size.xxsmall
+            }
+        }
+    }
+};
+export default Tabs;

--- a/themes/cerveza/components/Tabs.ts
+++ b/themes/cerveza/components/Tabs.ts
@@ -1,0 +1,30 @@
+import { color, size } from '../variables';
+
+const Tabs = {
+
+    props : {
+
+        MuiTabs: {
+            indicatorColor: 'primary',
+            textColor: 'primary',
+        },
+    },
+
+    overrides: {
+
+        MuiTabs: {
+
+            root: {
+                borderBottom: '2px solid ' + color.brand.tertiary,
+            },
+
+            indicator: {
+                height: size.xxsmall,
+            },
+        },
+
+    },
+
+};
+
+export default Tabs;

--- a/themes/cerveza/components/Tooltip.d.ts
+++ b/themes/cerveza/components/Tooltip.d.ts
@@ -1,0 +1,25 @@
+declare const Tooltip: {
+    props: {
+        MuiTooltip: {
+            arrow: boolean;
+        };
+    };
+    overrides: {
+        MuiTooltip: {
+            tooltip: {
+                padding: string;
+                fontSize: string;
+                backgroundColor: string;
+                color: string;
+                minWidth: string;
+                maxWidth: string;
+                borderRadius: string;
+                boxShadow: string;
+            };
+            arrow: {
+                color: string;
+            };
+        };
+    };
+};
+export default Tooltip;

--- a/themes/cerveza/components/Tooltip.js
+++ b/themes/cerveza/components/Tooltip.js
@@ -1,0 +1,26 @@
+import { color, size } from '../variables';
+var Tooltip = {
+    props: {
+        MuiTooltip: {
+            arrow: true
+        }
+    },
+    overrides: {
+        MuiTooltip: {
+            tooltip: {
+                padding: size.small,
+                fontSize: size.small,
+                backgroundColor: color.accent.info,
+                color: color.blueGray.lightest,
+                minWidth: '150px',
+                maxWidth: '240px',
+                borderRadius: size.xxsmall,
+                boxShadow: '0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12)'
+            },
+            arrow: {
+                color: color.accent.info
+            }
+        }
+    }
+};
+export default Tooltip;

--- a/themes/cerveza/components/Tooltip.ts
+++ b/themes/cerveza/components/Tooltip.ts
@@ -1,0 +1,37 @@
+import { color, size } from '../variables';
+
+const Tooltip = {
+
+    props: {
+
+        MuiTooltip: {
+            arrow: true,
+        },
+    },
+
+    overrides: {
+
+        MuiTooltip: {
+
+            tooltip: {
+                padding: size.small,
+                fontSize: size.small,
+                backgroundColor: color.accent.info,
+                color: color.blueGray.lightest,
+                minWidth: '150px',
+                maxWidth: '240px',
+                borderRadius: size.xxsmall,
+                boxShadow: '0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12)',
+            },
+
+            arrow: {
+                color: color.accent.info,
+            },
+
+        },
+
+    },
+
+};
+
+export default Tooltip;

--- a/themes/cerveza/index.js
+++ b/themes/cerveza/index.js
@@ -19,6 +19,7 @@ import Select from './components/Select';
 import Switch from './components/Switch';
 import Tabs from './components/Tabs';
 import Tab from './components/Tab';
+import Tooltip from './components/Tooltip';
 var Cerveza = createMuiTheme(_merge({
     palette: {
         primary: {
@@ -47,5 +48,5 @@ var Cerveza = createMuiTheme(_merge({
             primary: color.gray.dark
         }
     }
-}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput, Tabs, Tab));
+}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput, Tabs, Tab, Tooltip));
 export default Cerveza;

--- a/themes/cerveza/index.js
+++ b/themes/cerveza/index.js
@@ -17,6 +17,8 @@ import InputLabel from './components/InputLabel';
 import OutlinedInput from './components/OutlinedInput';
 import Select from './components/Select';
 import Switch from './components/Switch';
+import Tabs from './components/Tabs';
+import Tab from './components/Tab';
 var Cerveza = createMuiTheme(_merge({
     palette: {
         primary: {
@@ -45,5 +47,5 @@ var Cerveza = createMuiTheme(_merge({
             primary: color.gray.dark
         }
     }
-}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput));
+}, Typography, Alert, AlertTitle, Badge, Button, ButtonGroup, CircularProgress, Checkbox, Radio, Select, Switch, TextField, FormHelperText, FormControlLabel, InputLabel, OutlinedInput, Tabs, Tab));
 export default Cerveza;

--- a/themes/cerveza/index.ts
+++ b/themes/cerveza/index.ts
@@ -19,6 +19,8 @@ import InputLabel from './components/InputLabel';
 import OutlinedInput from './components/OutlinedInput';
 import Select from './components/Select';
 import Switch from './components/Switch';
+import Tabs from './components/Tabs';
+import Tab from './components/Tab';
 
 
 // @ts-ignore
@@ -78,6 +80,8 @@ const Cerveza = createMuiTheme(_merge(
     FormControlLabel,
     InputLabel,
     OutlinedInput,
+    Tabs,
+    Tab,
 ));
 
 

--- a/themes/cerveza/index.ts
+++ b/themes/cerveza/index.ts
@@ -21,6 +21,7 @@ import Select from './components/Select';
 import Switch from './components/Switch';
 import Tabs from './components/Tabs';
 import Tab from './components/Tab';
+import Tooltip from './components/Tooltip';
 
 
 // @ts-ignore
@@ -82,6 +83,7 @@ const Cerveza = createMuiTheme(_merge(
     OutlinedInput,
     Tabs,
     Tab,
+    Tooltip,
 ));
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds theme overrides for MuiTabs, MuiTab and MuiTooltip components according to the ProUI style guide.

The ProUI style guide defines three tooltip variants, differentiating based on the background-color: info, success and danger.
This pull request uses info background-color (color.accent.info) . Other variants must be created by wrapping the MuiTooltip component and e.g. adding a `color` prop.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.