### PR TITLE
fix: 🐛 helperText dark theme integration + tiny animate fix

### DIFF
--- a/src/components/FormField/index.tsx
+++ b/src/components/FormField/index.tsx
@@ -81,7 +81,14 @@ export const FormField = React.forwardRef(({
 
         return (
             <AnimatePresence>
-                <motion.span key={key} layout style={{ display: 'inline-block' }} {...fadeAnim}>
+                <motion.span
+                    key={key}
+                    layout
+                    style={{
+                        display: 'inline-block',
+                        position: 'absolute',
+                    }}
+                    {...fadeAnim}>
                     {content}
                 </motion.span>
             </AnimatePresence>

--- a/themes/cerveza-dark/components/TextField.ts
+++ b/themes/cerveza-dark/components/TextField.ts
@@ -1,0 +1,19 @@
+import { color } from '../../cerveza/variables';
+
+const OutlinedInput = {
+
+    overrides: {
+
+        MuiFormHelperText: {
+            root: {
+                color: color.gray.light,
+            },
+        },
+
+    },
+
+
+};
+
+
+export default OutlinedInput;

--- a/themes/cerveza-dark/index.ts
+++ b/themes/cerveza-dark/index.ts
@@ -4,11 +4,14 @@ import Cerveza from '../cerveza';
 
 import InputLabel from './components/InputLabel';
 import OutlinedInput from './components/OutlinedInput';
+import TextField from './components/TextField';
 
-const CervezaDark = createMuiTheme(_merge({},
+const CervezaDark = createMuiTheme(_merge(
+    {},
     Cerveza,
     InputLabel,
     OutlinedInput,
+    TextField,
 ));
 
 


### PR DESCRIPTION
## Description
Fixed theming issue with TextField helperText prop on CervezaDark. 
Fixed ugly animation when switching from helper text error state to regular text


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.